### PR TITLE
Feature/prevent directory listings

### DIFF
--- a/core.php
+++ b/core.php
@@ -7,7 +7,7 @@
  * Author:             Modern Tribe
  * Author URI:         https://tri.be
  * Text Domain:        tribe-storage
- * Version:            2.2.1
+ * Version:            2.3.0
  * Requires at least:  5.6
  * Requires PHP:       7.3
  */

--- a/src/Providers/Tribe_Storage_Provider.php
+++ b/src/Providers/Tribe_Storage_Provider.php
@@ -88,7 +88,7 @@ class Tribe_Storage_Provider implements Providable {
 		}, 9, 1 );
 
 		add_filter( 'pre_wp_unique_filename_file_list', function ( $files, $dir, $filename ) {
-			return $this->upload_dir->bypass_directory_listing( $files, (string) $dir, (string) $filename );
+			return $this->upload_dir->filter_unique_file_list( $files, (string) $dir, (string) $filename );
 		}, 10, 3);
 	}
 

--- a/src/Providers/Tribe_Storage_Provider.php
+++ b/src/Providers/Tribe_Storage_Provider.php
@@ -86,6 +86,10 @@ class Tribe_Storage_Provider implements Providable {
 		add_filter( 'wp_image_editors', function ( array $editors ) {
 			return $this->upload_dir->image_editors( $editors );
 		}, 9, 1 );
+
+		add_filter( 'pre_wp_unique_filename_file_list', function ( $files, $dir, $filename ) {
+			return $this->upload_dir->bypass_directory_listing( $files, (string) $dir, (string) $filename );
+		}, 10, 3);
 	}
 
 	/**

--- a/src/Uploads/Upload_Manager.php
+++ b/src/Uploads/Upload_Manager.php
@@ -204,7 +204,7 @@ class Upload_Manager {
 	 * Prevent WordPress from doing full directory listings on remote storage
 	 * when uploading files.
 	 *
-	 * @filter get_files_for_unique_filename_file_list
+	 * @filter pre_wp_unique_filename_file_list
 	 *
 	 * @param  array|null  $files
 	 * @param  string      $dir

--- a/src/Uploads/Upload_Manager.php
+++ b/src/Uploads/Upload_Manager.php
@@ -200,4 +200,48 @@ class Upload_Manager {
 		return [ 'WP_Image_Editor_Imagick' ];
 	}
 
+	/**
+	 * Prevent WordPress from doing full directory listings on remote storage
+	 * when uploading files.
+	 *
+	 * @filter get_files_for_unique_filename_file_list
+	 *
+	 * @param  array|null  $files
+	 * @param  string      $dir
+	 * @param  string      $filename
+	 *
+	 * @return array
+	 */
+	public function bypass_directory_listing( ?array $files, string $dir, string $filename ): array {
+		$full_path = trailingslashit( $dir ) . $filename;
+		$exists    = $this->filesystem->has( $full_path );
+
+		$meep = wp_get_additional_image_sizes();
+		$moop = get_intermediate_image_sizes();
+
+		// This file exists, return it WordPress so it can make it unique
+		if ( $exists ) {
+			return [
+				$filename,
+			];
+		}
+
+		// Default to a file that is highly unlikely to exist, so WordPress will do its regular processing
+		return [
+			$this->get_fake_file_name(),
+		];
+	}
+
+	/**
+	 * Create a file name that is highly unlikely to exist on remote storage.
+	 *
+	 * @return string
+	 */
+	protected function get_fake_file_name(): string {
+		return (string) apply_filters(
+			'tribe/storage/upload/fake_file_name',
+			'3debf56855bad8fa0d38d4eb45efe98432d549612703f0b04f7e2ebe9ef28a863fdffc5a8b322524712cf26f5e7efc4ea5a19255f0d30a527e9306b7ee49e2d3.jpg'
+		);
+	}
+
 }

--- a/src/Uploads/Upload_Manager.php
+++ b/src/Uploads/Upload_Manager.php
@@ -216,10 +216,7 @@ class Upload_Manager {
 		$full_path = trailingslashit( $dir ) . $filename;
 		$exists    = $this->filesystem->has( $full_path );
 
-		$meep = wp_get_additional_image_sizes();
-		$moop = get_intermediate_image_sizes();
-
-		// This file exists, return it WordPress so it can make it unique
+		// This file exists, return it to WordPress so it can make it unique
 		if ( $exists ) {
 			return [
 				$filename,


### PR DESCRIPTION
Prevent WordPress from running `@scandir()` in `wp_unique_filename()` as WordPress installs with month/year media organization disabled, can have a massive listing of files that will cause severe performance problems when uploading images.

This update will use Flysystem directly to search for matching file names, and with caching enabled will significantly faster at retrieving duplicates. 